### PR TITLE
chore: enable renovate for go dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,31 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    ":semanticCommits"
-  ],
-  "timezone": "Europe/Berlin",
-  "schedule": ["before 6am on Monday"],
-  "labels": ["dependencies"],
+  "extends": ["github>spring-media/curation-github-actions-shared//renovate/autocuration"],
   "enabledManagers": ["gomod"],
   "additionalBranchPrefix": "{{parentDir}}-",
   "gomod": {
     "postUpdateOptions": ["gomodTidy"]
-  },
-  "vulnerabilityAlerts": {
-    "enabled": true
-  },
-  "packageRules": [
-    {
-      "description": "Group minor and patch updates per package directory, so each PR only touches one package",
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "{{parentDir}} minor and patch dependencies"
-    },
-    {
-      "description": "Major updates handled individually, scoped per package directory",
-      "matchUpdateTypes": ["major"],
-      "groupName": null,
-      "automerge": false
-    }
-  ]
+  }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits"
+  ],
+  "timezone": "Europe/Berlin",
+  "schedule": ["before 6am on Monday"],
+  "labels": ["dependencies"],
+  "enabledManagers": ["gomod"],
+  "additionalBranchPrefix": "{{parentDir}}-",
+  "gomod": {
+    "postUpdateOptions": ["gomodTidy"]
+  },
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "packageRules": [
+    {
+      "description": "Group minor and patch updates per package directory, so each PR only touches one package",
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "{{parentDir}} minor and patch dependencies"
+    },
+    {
+      "description": "Major updates handled individually, scoped per package directory",
+      "matchUpdateTypes": ["major"],
+      "groupName": null,
+      "automerge": false
+    }
+  ]
+}


### PR DESCRIPTION
Adds a repo-root renovate.json for CD-1160.

4 independent go modules live under pkg/ (csvexport, s3logger, cloudwatchmetrics, testcontainers), each its own go.mod, no go.work tying them together.

additionalBranchPrefix (`{{parentDir}}-`) plus per-directory groupName on minor/patch updates keep each package's dependency updates isolated in their own PR, same pattern as curation-lambda (#285).